### PR TITLE
Graphresolve cleanups

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
@@ -26,7 +26,7 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 
 		public long CalculateRemainingVsizeCredentials(int maxRegistrableSize) => maxRegistrableSize - TotalInputVsize;
 
-		public Money CalculateRemainingAmountCredentials(FeeRate feeRate) => TotalInputAmount - feeRate.GetFee(TotalInputVsize);
+		public Money CalculateRemainingAmountCredentials(FeeRate feeRate) => Coin.EffectiveValue(feeRate);
 
 		public void SetDeadlineRelativeTo(TimeSpan connectionConfirmationTimeout)
 		{

--- a/WalletWasabi/WabiSabi/Client/BobClient.cs
+++ b/WalletWasabi/WabiSabi/Client/BobClient.cs
@@ -30,7 +30,7 @@ namespace WalletWasabi.WabiSabi.Client
 				cancellationToken).ConfigureAwait(false);
 		}
 
-		public async Task<(Credential[] RealAmountCredentials, Credential[] RealVsizeCredentials)> ReissueCredentialsAsync(
+		public async Task<(IEnumerable<Credential> RealAmountCredentials, IEnumerable<Credential> RealVsizeCredentials)> ReissueCredentialsAsync(
 			IEnumerable<long> amountsToRequest,
 			IEnumerable<long> vsizesToRequest,
 			IEnumerable<Credential> amountCredential,

--- a/WalletWasabi/WabiSabi/Client/SmartRequestNode.cs
+++ b/WalletWasabi/WabiSabi/Client/SmartRequestNode.cs
@@ -50,11 +50,19 @@ namespace WalletWasabi.WabiSabi.Client
 				inputVsizeCredentials,
 				cancellationToken).ConfigureAwait(false);
 
-			foreach ((TaskCompletionSource<Credential> tcs, Credential credential) in AmountCredentialTasks.Zip(result.RealAmountCredentials))
+			// TODO keep the credentials that were not needed by the graph
+			var amountCredentials = result.RealAmountCredentials.Take(amounts.Count());
+			var vsizeCredentials = result.RealVsizeCredentials.Take(vsizes.Count());
+
+			// TODO remove
+			amountCredentials = amountCredentials.Concat(Enumerable.Range(0, AmountCredentialTasks.Count() - amountCredentials.Count()).Select(_ => ZeroAmountCredentialPool.GetZeroCredential()));
+			vsizeCredentials = vsizeCredentials.Concat(Enumerable.Range(0, VsizeCredentialTasks.Count() - vsizeCredentials.Count()).Select(_ => ZeroVsizeCredentialPool.GetZeroCredential()));
+
+			foreach ((TaskCompletionSource<Credential> tcs, Credential credential) in AmountCredentialTasks.Zip(amountCredentials))
 			{
 				tcs.SetResult(credential);
 			}
-			foreach ((TaskCompletionSource<Credential> tcs, Credential credential) in VsizeCredentialTasks.Zip(result.RealVsizeCredentials))
+			foreach ((TaskCompletionSource<Credential> tcs, Credential credential) in VsizeCredentialTasks.Zip(vsizeCredentials))
 			{
 				tcs.SetResult(credential);
 			}

--- a/WalletWasabi/WabiSabi/Client/SmartRequestNode.cs
+++ b/WalletWasabi/WabiSabi/Client/SmartRequestNode.cs
@@ -43,7 +43,7 @@ namespace WalletWasabi.WabiSabi.Client
 			var amountsToRequest = AddExtraCredential(amounts, inputAmountCredentials);
 			var vsizesToRequest = AddExtraCredential(vsizes, inputVsizeCredentials);
 
-			(Credential[] RealAmountCredentials, Credential[] RealVsizeCredentials) result = await bobClient.ReissueCredentialsAsync(
+			(IEnumerable<Credential> RealAmountCredentials, IEnumerable<Credential> RealVsizeCredentials) result = await bobClient.ReissueCredentialsAsync(
 				amountsToRequest,
 				vsizesToRequest,
 				inputAmountCredentials,


### PR DESCRIPTION
Rebased everything on top of our last work.

One test still fails due to cancelled task (the one with the 10k sats input), need to investigate.

The first 3 commits can be taken with a fast forward merge, they are bug fixes and cleanups. The 4th is incomplete, could be made more complete, merged as is, or dropped, your call.

The 5th commit uncomments tests.

The 6th commit contains minimal changes to request the input values, but should be moved to a `SmartRequestNode.StartConnectionConfirmation` method to fix the code duplication.

The 7th commit hacks the decomposed output values in order to always request all sats credentials. This makes the tests pass, but is a privacy leak. I don't mind adding it now since deterministic greedy decomposition is a privacy leak anyway.

The 8th/final commit is empty, just a reminder to do the ready to sign signalling so that the 7th commit can be discarded or reverted depending on whether or not we merge it.