### PR TITLE
Graph cleanups wip

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -50,9 +50,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 		[Theory]
 		[InlineData(new long[] { 20_000_000, 40_000_000, 60_000_000, 80_000_000 })]
 		[InlineData(new long[] { 10_000_000, 20_000_000, 30_000_000, 40_000_000, 100_000_000 })]
-		//[InlineData(new long[] { 10_000_000, 20_000_000, 30_000_000, 40_000_000, 100_000_000 }, new long[] { 100_000_000, 100_000_000 })] //failing test
+		[InlineData(new long[] { 10_000_000, 20_000_000, 30_000_000, 40_000_000, 100_000_000 }, new long[] { 100_000_000, 100_000_000 })] //failing test
 		[InlineData(new long[] { 120_000_000 }, new long[] { 20_000_000, 40_000_000, 60_000_000 })]
-		//[InlineData(new long[] { 100_000_000, 10_000_000, 10_000 })] // failing test
+		[InlineData(new long[] { 100_000_000, 10_000_000, 10_000 })] // failing test
 		public async Task SoloCoinJoinTestAsync(long[] amounts, long[]? outputs = null)
 		{
 			int inputCount = amounts.Length;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -60,6 +60,12 @@ namespace WalletWasabi.WabiSabi.Client
 			var allLockedInternalKeys = Keymanager.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked);
 			var outputTxOuts = outputValues.Zip(allLockedInternalKeys, (amount, hdPubKey) => new TxOut(amount, hdPubKey.P2wpkhScript));
 
+			// TODO remove
+			var mutableTxOuts = outputTxOuts.ToArray();
+			var missing = Coins.Sum(c => c.EffectiveValue(roundState.FeeRate)) - outputTxOuts.Sum(o => o.EffectiveCost(roundState.FeeRate));
+			mutableTxOuts[0].Value += missing;
+			outputTxOuts = mutableTxOuts;
+
 			DependencyGraph dependencyGraph = DependencyGraph.ResolveCredentialDependencies(Coins, outputTxOuts, roundState.FeeRate, roundState.MaxVsizeAllocationPerAlice);
 
 			List<AliceClient> aliceClients = CreateAliceClients(roundState);


### PR DESCRIPTION
Solo coinjoin tests pass because of the 7th commit (which leaves no sats credentials unused), but I don't understand why that solves it yet, so it need to be investigated further.

The first 4 commits are the same as in #31

The 5th commit uncomments failing tests.

The 6th commit contains minimal changes to request the input values, but should be moved to a `SmartRequestNode.StartConnectionConfirmation` method to fix the code duplication.

The 7th commit hacks the decomposed output values in order to always request all sats credentials. This makes the tests pass, but is a privacy leak. I don't mind adding it now since deterministic greedy decomposition is a privacy leak anyway.

The 8th/final commit is empty, just a reminder to do the ready to sign signalling so that the 7th commit can be discarded or reverted depending on whether or not we merge it.