### PR TITLE
Merge Alice ID -> Secret into event sourcing WIP

### DIFF
--- a/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
+++ b/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.EventSourcing;
+using WalletWasabi.EventSourcing.ArenaDomain;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Banning;
 using WalletWasabi.WabiSabi.Backend.Rounds;
@@ -32,7 +33,9 @@ namespace WalletWasabi.Tests.Helpers
 			Network network = Network ?? Network.Main;
 
 			var repo = new InMemoryEventRepository();
-			Arena arena = new(period, network, config, rpc, prison, new EventStore(repo), repo);
+			var aggregateFactory = new AggregateFactory();
+			var commandProcessorFactory = new CommandProcessorFactory();
+			Arena arena = new(period, network, config, rpc, prison, new EventStore(repo, aggregateFactory, commandProcessorFactory), repo);
 
 			foreach (var round in rounds)
 			{

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -13,6 +13,7 @@ using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Crypto.ZeroKnowledge;
 using WalletWasabi.EventSourcing;
+using WalletWasabi.EventSourcing.ArenaDomain;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Banning;
 using WalletWasabi.WabiSabi.Backend.Models;
@@ -110,7 +111,8 @@ namespace WalletWasabi.Tests.Helpers
 
 		public static async Task<Arena> CreateAndStartArenaAsync(WabiSabiConfig cfg, IMock<IRPCClient> mockRpc, params Round[] rounds)
 		{
-			Arena arena = new(TimeSpan.FromHours(1), Network.Main, cfg, mockRpc.Object, new Prison(), new EventStore(new InMemoryEventRepository()));
+			var repository = new InMemoryEventRepository();
+			Arena arena = new(TimeSpan.FromHours(1), Network.Main, cfg, mockRpc.Object, new Prison(), new EventStore(repository, new AggregateFactory(), new CommandProcessorFactory()), repository);
 			foreach (var round in rounds)
 			{
 				arena.Rounds.Add(round);
@@ -224,7 +226,7 @@ namespace WalletWasabi.Tests.Helpers
 
 			return new ConnectionConfirmationRequest(
 				round.Id,
-				alice.Id,
+				alice.Secret,
 				zeroAmountCredentialRequest,
 				realAmountCredentialRequest,
 				zeroVsizeCredentialRequest,

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ReadyToSignRequestRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ReadyToSignRequestRequestTests.cs
@@ -18,15 +18,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			Guid guid = Guid.NewGuid();
 
 			// Request #1.
-			ReadyToSignRequestRequest request1 = new(RoundId: roundId, AliceId: guid);
+			ReadyToSignRequestRequest request1 = new(RoundId: roundId, AliceSecret: guid);
 
 			// Request #2.
-			ReadyToSignRequestRequest request2 = new(RoundId: roundId, AliceId: guid);
+			ReadyToSignRequestRequest request2 = new(RoundId: roundId, AliceSecret: guid);
 
 			Assert.Equal(request1, request2);
 
 			// Request #3.
-			ReadyToSignRequestRequest request3 = new(RoundId: BitcoinFactory.CreateUint256(), AliceId: guid);
+			ReadyToSignRequestRequest request3 = new(RoundId: BitcoinFactory.CreateUint256(), AliceSecret: guid);
 
 			Assert.NotEqual(request1, request3);
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
@@ -32,7 +32,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			await arena.RemoveInputAsync(req, CancellationToken.None);
 
 			// There was the alice we want to remove so success.
-			req = new InputsRemovalRequest(round.Id, alice.Id);
+			req = new InputsRemovalRequest(round.Id, alice.Secret);
 			await arena.RemoveInputAsync(req, CancellationToken.None);
 
 			// Ensure that removing an alice freed up the input vsize

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConnectionConfirmationRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConnectionConfirmationRequestTests.cs
@@ -28,7 +28,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			// Request #1.
 			ConnectionConfirmationRequest request1 = new(
 				RoundId: roundId,
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -38,7 +38,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #2.
 			ConnectionConfirmationRequest request2 = new(
 				RoundId: roundId,
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -50,7 +50,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #3.
 			ConnectionConfirmationRequest request3 = new(
 				RoundId: BitcoinFactory.CreateUint256(), // Intentionally changed.
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -62,7 +62,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #4.
 			ConnectionConfirmationRequest request4 = new(
 				RoundId: roundId,
-				AliceId: Guid.NewGuid(), // Intentionally changed.
+				AliceSecret: Guid.NewGuid(), // Intentionally changed.
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -74,7 +74,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #5.
 			ConnectionConfirmationRequest request5 = new(
 				RoundId: roundId,
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1337), // Intentionally changed.
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -86,7 +86,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #6.
 			ConnectionConfirmationRequest request6 = new(
 				RoundId: roundId,
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1337), // Intentionally changed.
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -98,7 +98,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #7.
 			ConnectionConfirmationRequest request7 = new(
 				RoundId: roundId,
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 1337), // Intentionally changed.
@@ -110,7 +110,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			// Request #8.
 			ConnectionConfirmationRequest request8 = new(
 				RoundId: roundId,
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -121,7 +121,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		}
 
 		private static GroupElement NewGroupElement(int i) => Generators.FromText($"T{i}");
+
 		private static GroupElementVector NewGroupElementVector(params int[] arr) => new(arr.Select(i => NewGroupElement(i)));
+
 		private static ScalarVector NewScalarVector(params uint[] arr) => new(arr.Select(i => new Scalar(i)));
 
 		/// <remarks>Each instance represents the same request but a new object instance.</remarks>

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputsRemovalRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputsRemovalRequestTests.cs
@@ -18,15 +18,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			Guid guid = Guid.NewGuid();
 
 			// Request #1.
-			InputsRemovalRequest request1 = new(RoundId: roundId, AliceId: guid);
+			InputsRemovalRequest request1 = new(RoundId: roundId, AliceSecret: guid);
 
 			// Request #2.
-			InputsRemovalRequest request2 = new(RoundId: roundId, AliceId: guid);
+			InputsRemovalRequest request2 = new(RoundId: roundId, AliceSecret: guid);
 
 			Assert.Equal(request1, request2);
 
 			// Request #3.
-			InputsRemovalRequest request3 = new(RoundId: BitcoinFactory.CreateUint256(), AliceId: guid);
+			InputsRemovalRequest request3 = new(RoundId: BitcoinFactory.CreateUint256(), AliceSecret: guid);
 
 			Assert.NotEqual(request1, request3);
 		}

--- a/WalletWasabi/EventSourcing/ArenaDomain/Aggregates/RoundAggregate.cs
+++ b/WalletWasabi/EventSourcing/ArenaDomain/Aggregates/RoundAggregate.cs
@@ -24,12 +24,12 @@ namespace WalletWasabi.EventSourcing.ArenaDomain
 
 		private void Apply(InputRegisteredEvent ev)
 		{
-			State = State with { Inputs = State.Inputs.Add(new InputState(ev.AliceId, ev.Coin, ev.OwnershipProof)) };
+			State = State with { Inputs = State.Inputs.Add(new InputState(ev.Coin, ev.OwnershipProof, ev.AliceSecret)) };
 		}
 
 		private void Apply(InputUnregistered ev)
 		{
-			State = State with { Inputs = State.Inputs.RemoveAll(input => input.AliceId == ev.AliceId) };
+			State = State with { Inputs = State.Inputs.RemoveAll(input => input.Coin.Outpoint == ev.AliceOutPoint) };
 		}
 
 		private void Apply(InputsConnectionConfirmationStartedEvent _)
@@ -39,11 +39,11 @@ namespace WalletWasabi.EventSourcing.ArenaDomain
 
 		private void Apply(InputConnectionConfirmedEvent ev)
 		{
-			var index = State.Inputs.FindIndex(input => input.AliceId == ev.AliceId);
+			var index = State.Inputs.FindIndex(input => input.Coin.Outpoint == ev.Coin.Outpoint);
 			if (index < 0)
 			{
 				// On client side we have to add the input here because InputRegisteredEvent not sent to clients.
-				State = State with { Inputs = State.Inputs.Add(new InputState(ev.AliceId, ev.Coin, ev.OwnershipProof, true)) };
+				State = State with { Inputs = State.Inputs.Add(new InputState(ev.Coin, ev.OwnershipProof, ConnectionConfirmed: true)) };
 				return;
 			}
 
@@ -69,7 +69,7 @@ namespace WalletWasabi.EventSourcing.ArenaDomain
 
 		private void Apply(InputReadyToSignEvent ev)
 		{
-			var index = State.Inputs.FindIndex(input => input.AliceId == ev.AliceId);
+			var index = State.Inputs.FindIndex(input => input.Coin.Outpoint == ev.AliceOutPoint);
 			if (index < 0)
 			{
 				return;
@@ -85,7 +85,7 @@ namespace WalletWasabi.EventSourcing.ArenaDomain
 
 		private void Apply(SignatureAddedEvent ev)
 		{
-			var index = State.Inputs.FindIndex(input => input.AliceId == ev.AliceId);
+			var index = State.Inputs.FindIndex(input => input.Coin.Outpoint == ev.AliceOutPoint);
 			if (index < 0)
 			{
 				return;

--- a/WalletWasabi/EventSourcing/ArenaDomain/Aggregates/RoundState2.cs
+++ b/WalletWasabi/EventSourcing/ArenaDomain/Aggregates/RoundState2.cs
@@ -24,9 +24,9 @@ namespace WalletWasabi.EventSourcing.ArenaDomain.Aggregates
 	}
 
 	public record InputState(
-		Guid AliceId,
 		Coin Coin,
 		OwnershipProof OwnershipProof,
+		Guid AliceSecret = default,
 		bool ConnectionConfirmed = false,
 		bool ReadyToSign = false,
 		WitScript? WitScript = null);

--- a/WalletWasabi/EventSourcing/ArenaDomain/Command/Commands.cs
+++ b/WalletWasabi/EventSourcing/ArenaDomain/Command/Commands.cs
@@ -11,9 +11,9 @@ using WalletWasabi.EventSourcing.Interfaces;
 namespace WalletWasabi.EventSourcing.ArenaDomain.Command
 {
 	public record StartRoundCommand(RoundParameters2 RoundParameters, Guid IdempotenceId) : ICommand;
-	public record InputRegisterCommand(Coin Coin, OwnershipProof OwnershipProof, Guid AliceId, Guid IdempotenceId) : ICommand;
-	public record InputConnectionConfirmedCommand(Coin Coin, OwnershipProof OwnershipProof, Guid AliceId, Guid IdempotenceId) : ICommand;
-	public record RemoveInputCommand(Guid AliceId, Guid IdempotenceId) : ICommand;
+	public record InputRegisterCommand(Coin Coin, OwnershipProof OwnershipProof, Guid AliceSecret, Guid IdempotenceId) : ICommand;
+	public record InputConnectionConfirmedCommand(Coin Coin, OwnershipProof OwnershipProof, Guid IdempotenceId) : ICommand;
+	public record RemoveInputCommand(OutPoint AliceOutPoint, Guid IdempotenceId) : ICommand;
 
 	public record RegisterOutputCommand(Script Script, long Value, Guid IdempotenceId) : ICommand;
 
@@ -25,9 +25,9 @@ namespace WalletWasabi.EventSourcing.ArenaDomain.Command
 
 	public record SucceedRoundCommand(Guid IdempotenceId) : ICommand;
 
-	public record InputReadyToSignCommand(Guid AliceId, Guid IdempotenceId) : ICommand;
+	public record InputReadyToSignCommand(OutPoint AliceOutPoint, Guid IdempotenceId) : ICommand;
 
-	public record AddSignatureEvent(Guid AliceId, WitScript WitScript, Guid IdempotenceId) : ICommand;
+	public record AddSignatureEvent(OutPoint AliceOutPoint, WitScript WitScript, Guid IdempotenceId) : ICommand;
 
 	public record EndRoundCommand(Guid IdempotenceId) : ICommand;
 }

--- a/WalletWasabi/EventSourcing/ArenaDomain/CommandProcessor/RoundCommandProcessor.cs
+++ b/WalletWasabi/EventSourcing/ArenaDomain/CommandProcessor/RoundCommandProcessor.cs
@@ -37,7 +37,7 @@ namespace WalletWasabi.EventSourcing.ArenaDomain.CommandProcessor
 			return errors.Count > 0 ?
 				Result.Fail(errors) :
 				Result.Succeed(
-					new[] { new InputRegisteredEvent(command.AliceId, command.Coin, command.OwnershipProof) });
+					new[] { new InputRegisteredEvent(command.AliceSecret, command.Coin, command.OwnershipProof) });
 		}
 
 		public Result Process(EndRoundCommand command, RoundState2 state)
@@ -47,12 +47,12 @@ namespace WalletWasabi.EventSourcing.ArenaDomain.CommandProcessor
 
 		public Result Process(InputConnectionConfirmedCommand command, RoundState2 state)
 		{
-			return Result.Succeed(new InputConnectionConfirmedEvent(command.AliceId, command.Coin, command.OwnershipProof));
+			return Result.Succeed(new InputConnectionConfirmedEvent(command.Coin, command.OwnershipProof));
 		}
 
 		public Result Process(RemoveInputCommand command, RoundState2 state)
 		{
-			return Result.Succeed(new InputUnregistered(command.AliceId));
+			return Result.Succeed(new InputUnregistered(command.AliceOutPoint));
 		}
 
 		public Result Process(RegisterOutputCommand command, RoundState2 state)
@@ -82,12 +82,12 @@ namespace WalletWasabi.EventSourcing.ArenaDomain.CommandProcessor
 
 		public Result Process(InputReadyToSignCommand command, RoundState2 state)
 		{
-			return Result.Succeed(new InputReadyToSignEvent(command.AliceId));
+			return Result.Succeed(new InputReadyToSignEvent(command.AliceOutPoint));
 		}
 
 		public Result Process(AddSignatureEvent command, RoundState2 state)
 		{
-			return Result.Succeed(new SignatureAddedEvent(command.AliceId, command.WitScript));
+			return Result.Succeed(new SignatureAddedEvent(command.AliceOutPoint, command.WitScript));
 		}
 
 		public Result Process(ICommand command, IState state)

--- a/WalletWasabi/EventSourcing/ArenaDomain/Events/InputConnectionConfirmedEvent.cs
+++ b/WalletWasabi/EventSourcing/ArenaDomain/Events/InputConnectionConfirmedEvent.cs
@@ -9,5 +9,5 @@ using WalletWasabi.EventSourcing.Interfaces;
 
 namespace WalletWasabi.EventSourcing.ArenaDomain.Events
 {
-	public record InputConnectionConfirmedEvent(Guid AliceId, Coin Coin, OwnershipProof OwnershipProof) : IEvent, IRoundClientEvent;
+	public record InputConnectionConfirmedEvent(Coin Coin, OwnershipProof OwnershipProof) : IEvent, IRoundClientEvent;
 }

--- a/WalletWasabi/EventSourcing/ArenaDomain/Events/InputReadyToSignEvent.cs
+++ b/WalletWasabi/EventSourcing/ArenaDomain/Events/InputReadyToSignEvent.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using NBitcoin;
 using WalletWasabi.EventSourcing.Interfaces;
 
 namespace WalletWasabi.EventSourcing.ArenaDomain.Events
 {
-	public record InputReadyToSignEvent(Guid AliceId) : IEvent;
+	public record InputReadyToSignEvent(OutPoint AliceOutPoint) : IEvent;
 }

--- a/WalletWasabi/EventSourcing/ArenaDomain/Events/InputRegisteredEvent.cs
+++ b/WalletWasabi/EventSourcing/ArenaDomain/Events/InputRegisteredEvent.cs
@@ -10,5 +10,5 @@ using WalletWasabi.WabiSabi.Backend.Rounds;
 
 namespace WalletWasabi.EventSourcing.ArenaDomain.Events
 {
-	public record InputRegisteredEvent(Guid AliceId, Coin Coin, OwnershipProof OwnershipProof) : IEvent;
+	public record InputRegisteredEvent(Guid AliceSecret, Coin Coin, OwnershipProof OwnershipProof) : IEvent;
 }

--- a/WalletWasabi/EventSourcing/ArenaDomain/Events/InputUnregistered.cs
+++ b/WalletWasabi/EventSourcing/ArenaDomain/Events/InputUnregistered.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using NBitcoin;
 using WalletWasabi.EventSourcing.Interfaces;
 
 namespace WalletWasabi.EventSourcing.ArenaDomain.Events
 {
-	public record InputUnregistered(Guid AliceId) : IEvent;
+	public record InputUnregistered(OutPoint AliceOutPoint) : IEvent;
 }

--- a/WalletWasabi/EventSourcing/ArenaDomain/Events/SignatureAddedEvent.cs
+++ b/WalletWasabi/EventSourcing/ArenaDomain/Events/SignatureAddedEvent.cs
@@ -8,5 +8,5 @@ using WalletWasabi.EventSourcing.Interfaces;
 
 namespace WalletWasabi.EventSourcing.ArenaDomain.Events
 {
-	public record SignatureAddedEvent(Guid AliceId, WitScript WitScript) : IEvent, IRoundClientEvent;
+	public record SignatureAddedEvent(OutPoint AliceOutPoint, WitScript WitScript) : IEvent, IRoundClientEvent;
 }

--- a/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
@@ -8,17 +8,17 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 {
 	public class Alice
 	{
-		public Alice(Coin coin, OwnershipProof ownershipProof, Round round, Guid id)
+		public Alice(Coin coin, OwnershipProof ownershipProof, Round round, Guid secret)
 		{
 			// TODO init syntax?
 			Round = round;
 			Coin = coin;
 			OwnershipProof = ownershipProof;
-			Id = id;
+			Secret = secret;
 		}
 
 		public Round Round { get; }
-		public Guid Id { get; }
+		public Guid Secret { get; }
 		public DateTimeOffset Deadline { get; set; } = DateTimeOffset.UtcNow;
 		public Coin Coin { get; }
 		public OwnershipProof OwnershipProof { get; }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -93,9 +93,9 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 				alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeFrame.Duration);
 
 				round.Alices.Add(alice);
-				await EventStore.ProcessCommandAsync(new InputRegisterCommand(alice.Coin, alice.OwnershipProof, alice.Id, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
+				await EventStore.ProcessCommandAsync(new InputRegisterCommand(alice.Coin, alice.OwnershipProof, alice.Secret, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
 
-				return new(alice.Id,
+				return new(alice.Secret,
 					commitAmountCredentialResponse,
 					commitVsizeCredentialResponse);
 			}
@@ -106,9 +106,9 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 			{
 				var round = GetRound(request.RoundId);
-				var alice = GetAlice(request.AliceId, round);
+				var alice = GetAlice(request.AliceSecret, round);
 				alice.ReadyToSign = true;
-				await EventStore.ProcessCommandAsync(new InputReadyToSignCommand(alice.Id, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
+				await EventStore.ProcessCommandAsync(new InputReadyToSignCommand(alice.Coin.Outpoint, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
 			}
 		}
 
@@ -123,9 +123,9 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 			{
 				var round = GetRound(request.RoundId, Phase.InputRegistration);
-				round.Alices.RemoveAll(x => x.Id == request.AliceId);
-
-				await EventStore.ProcessCommandAsync(new RemoveInputCommand(request.AliceId, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
+				var alice = GetAlice(request.AliceSecret, round);
+				round.Alices.Remove(alice);
+				await EventStore.ProcessCommandAsync(new RemoveInputCommand(alice.Coin.Outpoint, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
 			}
 		}
 
@@ -140,12 +140,12 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			{
 				round = GetRound(request.RoundId, Phase.InputRegistration, Phase.ConnectionConfirmation);
 
-				alice = GetAlice(request.AliceId, round);
+				alice = GetAlice(request.AliceSecret, round);
 
 				if (alice.ConfirmedConnection)
 				{
 					Prison.Ban(alice, round.Id);
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceAlreadyConfirmedConnection, $"Round ({request.RoundId}): Alice ({request.AliceId}) already confirmed connection.");
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceAlreadyConfirmedConnection, $"Round ({request.RoundId}): Alice ({request.AliceSecret}) already confirmed connection.");
 				}
 
 				if (realVsizeCredentialRequests.Delta != alice.CalculateRemainingVsizeCredentials(round.MaxVsizeAllocationPerAlice))
@@ -171,7 +171,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 			using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 			{
-				alice = GetAlice(request.AliceId, round);
+				alice = GetAlice(request.AliceSecret, round);
 
 				switch (round.Phase)
 				{
@@ -200,7 +200,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 							// Update the CoinJoin state, adding the confirmed input.
 							round.CoinjoinState = round.Assert<ConstructionState>().AddInput(alice.Coin);
 							alice.ConfirmedConnection = true;
-							await EventStore.ProcessCommandAsync(new InputConnectionConfirmedCommand(alice.Coin, alice.OwnershipProof, alice.Id, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
+							await EventStore.ProcessCommandAsync(new InputConnectionConfirmedCommand(alice.Coin, alice.OwnershipProof, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
 
 							return response;
 						}
@@ -258,7 +258,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					state = state.AddWitness((int)inputWitnessPair.InputIndex, inputWitnessPair.Witness);
 					var alice = round.Alices.Single(a => state.Inputs[(int)inputWitnessPair.InputIndex].Outpoint == a.Coin.Outpoint);
 
-					await EventStore.ProcessCommandAsync(new AddSignatureEvent(alice.Id, inputWitnessPair.Witness, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
+					await EventStore.ProcessCommandAsync(new AddSignatureEvent(alice.Coin.Outpoint, inputWitnessPair.Witness, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
 				}
 
 				// at this point all of the witnesses have been verified and the state can be updated
@@ -347,8 +347,8 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		private Round GetRound(uint256 roundId, params Phase[] phases) =>
 			InPhase(GetRound(roundId), phases);
 
-		private Alice GetAlice(Guid aliceId, Round round) =>
-			round.Alices.Find(x => x.Id == aliceId)
-			?? throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound, $"Round ({round.Id}): Alice ({aliceId}) not found.");
+		private Alice GetAlice(Guid aliceSecret, Round round) =>
+			round.Alices.Find(x => x.Secret == aliceSecret)
+			?? throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound, $"Round ({round.Id}): Alice ({aliceSecret}) not found.");
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -92,7 +92,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 						round.Alices.RemoveAll(x => offendingAlices.Contains(x));
 						foreach (var alice in offendingAlices)
 						{
-							await EventStore.ProcessCommandAsync(new RemoveInputCommand(alice.Id, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
+							await EventStore.ProcessCommandAsync(new RemoveInputCommand(alice.Coin.Outpoint, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
 						}
 					}
 				}
@@ -135,7 +135,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					var removedAliceCount = round.Alices.RemoveAll(x => alicesDidntConfirm.Contains(x));
 					foreach (var alice in alicesDidntConfirm)
 					{
-						await EventStore.ProcessCommandAsync(new RemoveInputCommand(alice.Id, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
+						await EventStore.ProcessCommandAsync(new RemoveInputCommand(alice.Coin.Outpoint, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
 					}
 
 					round.LogInfo($"{removedAliceCount} alices removed because they didn't confirm.");
@@ -152,7 +152,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 								var removed = round.Alices.RemoveAll(x => offendingAlices.Contains(x));
 								foreach (var alice in offendingAlices)
 								{
-									await EventStore.ProcessCommandAsync(new RemoveInputCommand(alice.Id, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
+									await EventStore.ProcessCommandAsync(new RemoveInputCommand(alice.Coin.Outpoint, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
 								}
 
 								round.LogInfo($"There were {removed} alices removed because they spent the registered UTXO.");
@@ -393,7 +393,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 				foreach (var alice in alicesToRemove)
 				{
 					round.Alices.Remove(alice);
-					await EventStore.ProcessCommandAsync(new RemoveInputCommand(alice.Id, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
+					await EventStore.ProcessCommandAsync(new RemoveInputCommand(alice.Coin.Outpoint, Guid.NewGuid()), nameof(RoundAggregate), round.Id.ToString()).ConfigureAwait(false);
 				}
 
 				if (alicesToRemove.Any())

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -51,12 +51,12 @@ namespace WalletWasabi.WabiSabi.Client
 			var realAmountCredentials = AmountCredentialClient.HandleResponse(inputRegistrationResponse.AmountCredentials, zeroAmountCredentialRequestData.CredentialsResponseValidation);
 			var realVsizeCredentials = VsizeCredentialClient.HandleResponse(inputRegistrationResponse.VsizeCredentials, zeroVsizeCredentialRequestData.CredentialsResponseValidation);
 
-			return new(inputRegistrationResponse.AliceId, realAmountCredentials, realVsizeCredentials);
+			return new(inputRegistrationResponse.AliceSecret, realAmountCredentials, realVsizeCredentials);
 		}
 
-		public async Task RemoveInputAsync(uint256 roundId, Guid aliceId, CancellationToken cancellationToken)
+		public async Task RemoveInputAsync(uint256 roundId, Guid aliceSecret, CancellationToken cancellationToken)
 		{
-			await RequestHandler.RemoveInputAsync(new InputsRemovalRequest(roundId, aliceId), cancellationToken).ConfigureAwait(false);
+			await RequestHandler.RemoveInputAsync(new InputsRemovalRequest(roundId, aliceSecret), cancellationToken).ConfigureAwait(false);
 		}
 
 		public async Task RegisterOutputAsync(

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -285,7 +285,7 @@ namespace WalletWasabi.WabiSabi.Client
 				}
 				catch (Exception e)
 				{
-					Logger.LogWarning($"Round ({aliceClient.RoundId}), Alice ({aliceClient.AliceId}): Could not sign, reason:'{e}'.");
+					Logger.LogWarning($"Round ({aliceClient.RoundId}), Alice ({aliceClient.SmartCoin.OutPoint}): Could not sign, reason:'{e}'.");
 					return default;
 				}
 			}

--- a/WalletWasabi/WabiSabi/Models/ConnectionConfirmationRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/ConnectionConfirmationRequest.cs
@@ -4,12 +4,12 @@ using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 
 namespace WalletWasabi.WabiSabi.Models
 {
-	public record ConnectionConfirmationRequest(
-		uint256 RoundId,
-		Guid AliceId,
-		ZeroCredentialsRequest ZeroAmountCredentialRequests,
-		RealCredentialsRequest RealAmountCredentialRequests,
-		ZeroCredentialsRequest ZeroVsizeCredentialRequests,
-		RealCredentialsRequest RealVsizeCredentialRequests
-	);
+    public record ConnectionConfirmationRequest(
+        uint256 RoundId,
+        Guid AliceSecret,
+        ZeroCredentialsRequest ZeroAmountCredentialRequests,
+        RealCredentialsRequest RealAmountCredentialRequests,
+        ZeroCredentialsRequest ZeroVsizeCredentialRequests,
+        RealCredentialsRequest RealVsizeCredentialRequests
+    );
 }

--- a/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
+++ b/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
@@ -5,7 +5,7 @@ using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 namespace WalletWasabi.WabiSabi.Models
 {
 	public record InputRegistrationResponse(
-		Guid AliceId,
+		Guid AliceSecret,
 		CredentialsResponse AmountCredentials,
 		CredentialsResponse VsizeCredentials
 	);

--- a/WalletWasabi/WabiSabi/Models/InputsRemovalRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/InputsRemovalRequest.cs
@@ -3,8 +3,8 @@ using NBitcoin;
 
 namespace WalletWasabi.WabiSabi.Models
 {
-	public record InputsRemovalRequest(
-		uint256 RoundId,
-		Guid AliceId
-	);
+    public record InputsRemovalRequest(
+        uint256 RoundId,
+        Guid AliceSecret
+    );
 }

--- a/WalletWasabi/WabiSabi/Models/ReadyToSignRequestRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/ReadyToSignRequestRequest.cs
@@ -3,5 +3,5 @@ using System;
 
 namespace WalletWasabi.WabiSabi.Backend.PostRequests
 {
-	public record ReadyToSignRequestRequest(uint256 RoundId, Guid AliceId);
+    public record ReadyToSignRequestRequest(uint256 RoundId, Guid AliceSecret);
 }


### PR DESCRIPTION
This continues the simple renaming in #6767 with changes necessary to keep this unique identifier secret in the event sourcing code.

WalletWasabi.Tests project doesn't build in upstream so only partial attempts at fixing it were made, but the client and backend have been tested and appear to be working.

Input registration still contains the secret, since the round aggregate keeps track of it it in the `InputState`, but clients will not see those events. On the client, each `InputState` will have the `default` `Guid` as its secret in the property which is otherwise unused.