### PR TITLE
Fix block cache pruning size limit

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Wallet/FileSystemBlockRepositoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/FileSystemBlockRepositoryTests.cs
@@ -1,0 +1,42 @@
+using NBitcoin;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Helpers;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.Wallets;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Wallet;
+
+public class FileSystemBlockRepositoryTests
+{
+	[Fact]
+	public async Task PrunesFilesOverConfiguredSizeAsync()
+	{
+		var workDir = Common.GetWorkDir();
+		await IoHelpers.TryDeleteDirectoryAsync(workDir);
+
+		try
+		{
+			Directory.CreateDirectory(workDir);
+			var oldFilePath = Path.Combine(workDir, "old-block");
+			await File.WriteAllBytesAsync(oldFilePath, new byte[1024 * 1024]);
+			File.SetLastAccessTimeUtc(oldFilePath, DateTime.UtcNow - TimeSpan.FromDays(1));
+
+			var repository = new FileSystemBlockRepository(workDir, Network.Main, targetBlocksFolderSizeInMegabytes: 1);
+			var block = Network.Main.Consensus.ConsensusFactory.CreateBlock();
+			block.Header.Nonce = 1;
+
+			await repository.SaveAsync(block, CancellationToken.None);
+
+			Assert.False(File.Exists(oldFilePath));
+			Assert.True(File.Exists(Path.Combine(workDir, block.GetHash().ToString())));
+		}
+		finally
+		{
+			await IoHelpers.TryDeleteDirectoryAsync(workDir);
+		}
+	}
+}

--- a/WalletWasabi/Wallets/FileSystemBlockRepository.cs
+++ b/WalletWasabi/Wallets/FileSystemBlockRepository.cs
@@ -18,13 +18,13 @@ public class FileSystemBlockRepository
 	{
 		BlocksFolderPath = blocksFolderPath;
 		_network = network;
-		_targetBlocksFolderSize = targetBlocksFolderSizeInMegabytes * MegaByte;
+		_targetBlocksFolderSizeBytes = targetBlocksFolderSizeInMegabytes * MegaByte;
 		RemoveBlockFolderForRegTest();
 	}
 
 	public string BlocksFolderPath { get; }
 	private readonly Network _network;
-	private readonly long _targetBlocksFolderSize;
+	private readonly long _targetBlocksFolderSizeBytes;
 	private readonly AsyncLock _blockFolderLock = new();
 
 	private void Prune()
@@ -36,7 +36,7 @@ public class FileSystemBlockRepository
 				.Select(x => new FileInfo(x))
 				.OrderByDescending(x => x.LastAccessTimeUtc)
 				.Scan((fileInfo:(FileInfo)null!, accumSize: 0L), (acc, fileInfo) => (fileInfo, acc.accumSize + fileInfo.Length))
-				.SkipWhile(x => x.accumSize < _targetBlocksFolderSize * MegaByte)
+				.SkipWhile(x => x.accumSize < _targetBlocksFolderSizeBytes)
 				.Select(x => x.fileInfo)
 				.ToArray();
 


### PR DESCRIPTION
## Summary

- compare the accumulated block-cache size against the configured byte limit without converting the limit a second time
- add a regression test proving that an old block is pruned when the cache reaches a one MiB target

## Test plan

- `dotnet test WalletWasabi.Tests/WalletWasabi.Tests.csproj -- --filter-class WalletWasabi.Tests.UnitTests.Wallet.FileSystemBlockRepositoryTests` (1 passed)
